### PR TITLE
perf(search): share transposition table across entire game

### DIFF
--- a/include/c3/engine.hpp
+++ b/include/c3/engine.hpp
@@ -24,6 +24,8 @@ public:
   Position& position() { return pos_; }
   const Position& position() const { return pos_; }
 
+  search::TranspositionTable& tt() { return tt_; }
+
   void new_game();
   void set_position(const Position& pos);
   void set_position_from_fen(const std::string& fen);
@@ -38,6 +40,7 @@ public:
 
 private:
   Position pos_;
+  mutable search::TranspositionTable tt_;
 };
 
 } // namespace c3

--- a/include/c3/search.hpp
+++ b/include/c3/search.hpp
@@ -235,8 +235,7 @@ struct SearchResult {
   std::uint32_t hashfull{0}; // permille of TT usage
 };
 
-SearchResult search(Position& pos, const Limits& limits, Reporter& reporter,
-                    TranspositionTable& tt,
+SearchResult search(Position& pos, const Limits& limits, Reporter& reporter, TranspositionTable& tt,
                     std::shared_ptr<std::atomic_bool> stop_signal = nullptr);
 SearchResult search(Position& pos, const Limits& limits, Reporter& reporter,
                     std::shared_ptr<std::atomic_bool> stop_signal = nullptr);

--- a/include/c3/search.hpp
+++ b/include/c3/search.hpp
@@ -172,6 +172,8 @@ public:
   [[nodiscard]] std::size_t usage() const { return usage_; }
   [[nodiscard]] std::size_t capacity() const { return capacity_; }
 
+  void clear();
+
   static void set_size_mb(std::size_t size_mb);
   static std::size_t size_mb();
 
@@ -233,6 +235,9 @@ struct SearchResult {
   std::uint32_t hashfull{0}; // permille of TT usage
 };
 
+SearchResult search(Position& pos, const Limits& limits, Reporter& reporter,
+                    TranspositionTable& tt,
+                    std::shared_ptr<std::atomic_bool> stop_signal = nullptr);
 SearchResult search(Position& pos, const Limits& limits, Reporter& reporter,
                     std::shared_ptr<std::atomic_bool> stop_signal = nullptr);
 SearchResult search(Position& pos, std::uint8_t depth);

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -8,6 +8,7 @@ Engine::Engine() : pos_(Position::startpos()) {}
 
 void Engine::new_game() {
   pos_ = Position::startpos();
+  tt_.clear();
 }
 
 void Engine::set_position(const Position& pos) {
@@ -31,12 +32,12 @@ void Engine::apply_moves(const std::vector<Move>& moves) {
 search::SearchResult Engine::search(const search::Limits& limits, search::Reporter& reporter,
                                     std::shared_ptr<std::atomic_bool> stop_signal) const {
   Position pos_copy = pos_;
-  return search::search(pos_copy, limits, reporter, std::move(stop_signal));
+  return search::search(pos_copy, limits, reporter, tt_, std::move(stop_signal));
 }
 
-void Engine::set_hash_size_mb(
-    std::size_t size_mb) { // NOLINT(readability-convert-member-functions-to-static)
+void Engine::set_hash_size_mb(std::size_t size_mb) {
   search::TranspositionTable::set_size_mb(size_mb);
+  tt_ = search::TranspositionTable();
 }
 
 } // namespace c3

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -625,8 +625,7 @@ int detail::alphabeta(Position& pos, std::uint8_t depth, int alpha, int beta, Mo
 // are in the final iteration (exponential growth of the tree).
 // ---------------------------------------------------------------------------
 
-SearchResult search(Position& pos, const Limits& limits, Reporter& reporter,
-                    TranspositionTable& tt,
+SearchResult search(Position& pos, const Limits& limits, Reporter& reporter, TranspositionTable& tt,
                     std::shared_ptr<std::atomic_bool> stop_signal) {
   Stopper stopper(std::move(stop_signal));
   stopper.at_depth(limits.depth);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -435,6 +435,9 @@ int detail::alphabeta(Position& pos, std::uint8_t depth, int alpha, int beta, Mo
 
       switch (entry->bound) {
       case Bound::Exact:
+        if (entry->move.has_value()) {
+          pv.push_back(*entry->move);
+        }
         return tt_eval; // Exact score: we're done
       case Bound::Lower:
         if (tt_eval >= beta) {

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -659,9 +659,9 @@ void run_loop_impl(std::istream& in,
         Position pos_copy = engine.position();
 
         search_handle.thread =
-            std::thread([pos_copy, limits, stop_signal, &out, &out_mutex]() mutable {
+            std::thread([pos_copy, limits, stop_signal, &out, &out_mutex, &engine]() mutable {
               UciReporter reporter(out, &out_mutex);
-              search::search(pos_copy, limits, reporter, stop_signal);
+              search::search(pos_copy, limits, reporter, engine.tt(), stop_signal);
 
               const auto best = reporter.best_move();
               std::scoped_lock lock(out_mutex);


### PR DESCRIPTION
## Summary

- Move TT ownership from `search()` to `Engine` class so cached positions persist between moves
- Add `TranspositionTable::clear()` method for resetting entries
- Update `search()` to accept TT by reference (with backward-compatible overloads)
- Clear TT on `ucinewgame` command
- Rebuild TT when hash size changes via `setoption`

## Why

The transposition table was previously created fresh for each `search()` call, discarding all cached positions between moves. This lost valuable work from previous searches and prevented the engine from benefiting from position reuse across a game.

With this change:
- Positions explored during move N are available for move N+1
- The engine avoids re-searching many of the same positions
- `hashfull` will increase during a game as more positions are cached

## Test plan

- [x] All 200 unit tests pass (`ctest --preset tests`)
- [x] Build succeeds with debug preset
- [ ] Manual verification: play multiple moves, observe increasing `hashfull` in UCI info
- [ ] Manual verification: `ucinewgame` resets `hashfull`

Closes #1