### PR TITLE
fix(ci): workflow improvements for strength-test

### DIFF
--- a/.github/workflows/strength-test.yml
+++ b/.github/workflows/strength-test.yml
@@ -114,8 +114,8 @@ jobs:
           wget -q https://github.com/Disservin/fastchess/releases/download/v1.7.0-alpha/fastchess-linux-x86-64.tar \
             -O /tmp/fastchess.tar
           tar -xf /tmp/fastchess.tar -C /tmp
-          chmod +x /tmp/fastchess
-          sudo mv /tmp/fastchess /usr/local/bin/fastchess
+          chmod +x /tmp/fastchess-linux-x86-64/fastchess
+          sudo mv /tmp/fastchess-linux-x86-64/fastchess /usr/local/bin/fastchess
 
       - name: Run SPRT comparison
         id: sprt

--- a/.github/workflows/strength-test.yml
+++ b/.github/workflows/strength-test.yml
@@ -111,8 +111,9 @@ jobs:
 
       - name: Install fastchess
         run: |
-          wget -q https://github.com/Disservin/fastchess/releases/latest/download/fastchess-linux-x86_64 \
-            -O /tmp/fastchess
+          wget -q https://github.com/Disservin/fastchess/releases/download/v1.7.0-alpha/fastchess-linux-x86-64.tar \
+            -O /tmp/fastchess.tar
+          tar -xf /tmp/fastchess.tar -C /tmp
           chmod +x /tmp/fastchess
           sudo mv /tmp/fastchess /usr/local/bin/fastchess
 

--- a/.github/workflows/strength-test.yml
+++ b/.github/workflows/strength-test.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           cd scripts
           python3 perft_benchmark.py \
-            --base ${{ github.base_ref }} \
+            --base origin/${{ github.base_ref }} \
             --test HEAD \
             --threshold 5.0 \
             | tee ../perft.txt
@@ -122,7 +122,7 @@ jobs:
         run: |
           cd scripts
           python3 compare_branches.py \
-            --base ${{ github.base_ref }} \
+            --base origin/${{ github.base_ref }} \
             --test HEAD \
             --games ${{ inputs.games || '200' }} \
             --depth ${{ inputs.depth || '5' }} \


### PR DESCRIPTION
## Summary

- Update fastchess download URL to use the correct v1.7.0-alpha release asset (tar archive instead of non-existent direct binary)
- Fix fastchess binary path after tar extraction
- Use `origin/` prefix for base ref in git worktree checkout to ensure the ref is correctly resolved in CI environment

## Changes

All changes are in `.github/workflows/strength-test.yml`:

1. **Fastchess installation**: The download URL was pointing to a non-existent binary. Updated to download the tar archive and extract it properly.

2. **Git ref resolution**: Added `origin/` prefix to `${{ github.base_ref }}` in both the perft benchmark and SPRT comparison steps, as the base ref needs the remote prefix when checking out in CI.