### PR TITLE
feat(search): add Syzygy tablebase support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ core
 
 .DS_Store
 Thumbs.db
+
+# Syzygy tablebase files (large, downloaded separately)
+syzygy/
+*.rtbw
+*.rtbz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,16 @@ set_target_properties(fathom_lib PROPERTIES
   C_STANDARD 99
   C_STANDARD_REQUIRED ON
 )
-if(NOT MSVC)
+# Fathom uses _mm_popcnt_u64 which requires popcnt CPU feature.
+# Suppress warnings from third-party code and enable required CPU features.
+if(MSVC)
+  # MSVC and clang-cl: enable popcnt via SSE4.2 and suppress deprecation warnings
+  target_compile_options(fathom_lib PRIVATE /W0 /D_CRT_SECURE_NO_WARNINGS)
+  if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    # clang-cl needs explicit popcnt enablement
+    target_compile_options(fathom_lib PRIVATE -mpopcnt -msse4.2)
+  endif()
+else()
   target_compile_options(fathom_lib PRIVATE -w)
 endif()
 if(CMAKE_CXX_CLANG_TIDY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 
-project(c3 LANGUAGES CXX)
+project(c3 LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -81,6 +81,30 @@ else()
   add_custom_target(generate_magic)
 endif()
 
+# Syzygy tablebase support via Fathom
+include(FetchContent)
+FetchContent_Declare(
+  fathom
+  GIT_REPOSITORY https://github.com/jdart1/Fathom.git
+  GIT_TAG master
+)
+FetchContent_MakeAvailable(fathom)
+
+add_library(fathom_lib STATIC
+  ${fathom_SOURCE_DIR}/src/tbprobe.c
+)
+target_include_directories(fathom_lib PUBLIC ${fathom_SOURCE_DIR}/src)
+set_target_properties(fathom_lib PROPERTIES
+  C_STANDARD 99
+  C_STANDARD_REQUIRED ON
+)
+if(NOT MSVC)
+  target_compile_options(fathom_lib PRIVATE -w)
+endif()
+if(CMAKE_CXX_CLANG_TIDY)
+  set_target_properties(fathom_lib PROPERTIES CXX_CLANG_TIDY "")
+endif()
+
 add_library(c3_core STATIC
   src/about.cpp
   src/eval.cpp
@@ -90,10 +114,12 @@ add_library(c3_core STATIC
   src/engine.cpp
   src/uci.cpp
   src/search.cpp
+  src/tablebase.cpp
 )
 target_compile_definitions(c3_core PUBLIC C3_TESTING)
 add_dependencies(c3_core generate_magic)
 target_include_directories(c3_core PUBLIC ${PROJECT_SOURCE_DIR}/include)
+target_link_libraries(c3_core PUBLIC fathom_lib)
 c3_apply_standard_settings(c3_core)
 
 add_executable(c3

--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ This project grew out of a fascination with chess programming and a desire to de
 - Full UCI protocol with time management
 - GoogleTest suite with perft validation
 - Fastchess gauntlet testing with SPRT
+- Syzygy tablebase support for perfect endgame play
 
 ## Roadmap
 
 - Late-move reductions (LMR)
 - Enhanced evaluation (king safety, pawn structure, endgame patterns)
 - Opening book support
-- Tablebase support
 - Multi-threaded search
 
 ## Usage
@@ -44,6 +44,21 @@ uci
 isready
 position startpos moves e2e4 e7e5
 go depth 10
+```
+
+### Tablebase Configuration
+
+Download Syzygy tablebase files (~1GB for 3-4-5 piece):
+
+```bash
+./scripts/download_syzygy.sh ./syzygy 345
+```
+
+Configure the engine to use them:
+
+```
+setoption name SyzygyPath value ./syzygy
+setoption name SyzygyProbeLimit value 6
 ```
 
 ## Prerequisites

--- a/include/c3/tablebase.hpp
+++ b/include/c3/tablebase.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include "c3/move.hpp"
+#include "c3/position.hpp"
+
+namespace c3::tablebase {
+
+// WDL result values matching Fathom's conventions
+enum class WdlResult : std::uint8_t {
+  Loss = 0,
+  BlessedLoss = 1,
+  Draw = 2,
+  CursedWin = 3,
+  Win = 4,
+  Failed = 5,
+};
+
+// Configuration for tablebase probing
+struct Config {
+  std::string path;
+  std::uint8_t probe_depth{1};
+  std::uint8_t probe_limit{7};
+  bool use_50_move_rule{true};
+};
+
+// Score constant for TB wins (below mate threshold, above any material)
+inline constexpr int CENTIPAWN_TB_WIN = 9000;
+
+void set_config(const Config& config);
+Config get_config();
+
+// Initialize tablebases from the configured path.
+// Returns the maximum piece count supported, or 0 if initialization failed.
+std::uint8_t init();
+
+// Check if tablebases are available and initialized.
+bool is_available();
+
+// Get the maximum piece count the loaded tablebases support.
+std::uint8_t max_pieces();
+
+// Free tablebase resources.
+void free();
+
+// Probe WDL for search cutoffs.
+// Returns Failed if probe is not possible (not available, too many pieces,
+// castling rights present, etc.)
+WdlResult probe_wdl(const Position& pos);
+
+// Probe DTZ at root to get the optimal move.
+// Returns nullopt if probe fails.
+std::optional<Move> probe_root_move(const Position& pos);
+
+// Convert WDL result to centipawn score for search.
+// Win/Loss scores are adjusted by ply to prefer faster wins / delay losses.
+int wdl_to_score(WdlResult wdl, std::uint8_t ply);
+
+} // namespace c3::tablebase

--- a/include/c3/tablebase.hpp
+++ b/include/c3/tablebase.hpp
@@ -1,5 +1,48 @@
 #pragma once
 
+// =============================================================================
+// ENDGAME TABLEBASES: Perfect Play from Precomputed Knowledge
+// =============================================================================
+//
+// Problem: In complex middlegames, engines rely on heuristics—but in simple
+// endgames (≤7 pieces), every position has been solved. King+Rook vs King is
+// always a win with perfect play, but how quickly? Which move is optimal?
+//
+// Solution: Syzygy tablebases store the game-theoretic result (win/draw/loss)
+// and distance-to-zeroing (DTZ) for all positions with up to 7 pieces. Instead
+// of searching millions of nodes, we look up the answer instantly.
+//
+// TWO TYPES OF PROBES:
+//
+// 1. WDL (Win/Draw/Loss) - Used during search for cutoffs
+//    Returns whether the position is won, drawn, or lost. Five possible values:
+//    - Win: Side to move wins with perfect play
+//    - CursedWin: Win, but will be drawn by 50-move rule
+//    - Draw: Neither side can force a win
+//    - BlessedLoss: Loss, but saved by 50-move rule
+//    - Loss: Side to move loses with perfect play
+//
+// 2. Root Probe (DTZ) - Used at search root for best move
+//    Returns the optimal move that either wins fastest or loses slowest.
+//    Only used at the root since it's more expensive than WDL.
+//
+// INTEGRATION POINTS:
+// - After TT probe in search: WDL cutoffs when depth >= probe_depth
+// - Before iterative deepening: Root probe for immediate tablebase moves
+//
+// CONFIGURATION (UCI options):
+// - SyzygyPath: Directory containing .rtbw (WDL) and .rtbz (DTZ) files
+// - SyzygyProbeDepth: Minimum depth before probing (default: 1)
+// - SyzygyProbeLimit: Max pieces to probe (default: 7, max available)
+// - Syzygy50MoveRule: Whether to respect 50-move rule in probes
+//
+// SCORE ENCODING:
+// TB wins score as CENTIPAWN_TB_WIN (9000), adjusted by ply to prefer faster
+// wins and delay losses. This is above any realistic material evaluation but
+// below mate scores, so the engine correctly prioritizes checkmate over TB wins.
+//
+// =============================================================================
+
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -9,22 +52,22 @@
 
 namespace c3::tablebase {
 
-// WDL result values matching Fathom's conventions
+// WDL probe results (values match Fathom library conventions)
 enum class WdlResult : std::uint8_t {
-  Loss = 0,
-  BlessedLoss = 1,
-  Draw = 2,
-  CursedWin = 3,
-  Win = 4,
-  Failed = 5,
+  Loss = 0,        // Side to move loses with perfect play
+  BlessedLoss = 1, // Would lose, but 50-move rule saves the draw
+  Draw = 2,        // Neither side can force a win
+  CursedWin = 3,   // Would win, but 50-move rule forces a draw
+  Win = 4,         // Side to move wins with perfect play
+  Failed = 5,      // Probe failed (TB unavailable, too many pieces, castling rights)
 };
 
-// Configuration for tablebase probing
+// Configuration for tablebase probing (set via UCI options)
 struct Config {
-  std::string path;
-  std::uint8_t probe_depth{1};
-  std::uint8_t probe_limit{7};
-  bool use_50_move_rule{true};
+  std::string path;              // Directory containing Syzygy files (.rtbw, .rtbz)
+  std::uint8_t probe_depth{1};   // Minimum search depth before probing TBs
+  std::uint8_t probe_limit{7};   // Max piece count to probe (saves time in complex positions)
+  bool use_50_move_rule{true};   // Whether DTZ respects the 50-move draw rule
 };
 
 // Score constant for TB wins (below mate threshold, above any material)

--- a/include/c3/tablebase.hpp
+++ b/include/c3/tablebase.hpp
@@ -64,10 +64,10 @@ enum class WdlResult : std::uint8_t {
 
 // Configuration for tablebase probing (set via UCI options)
 struct Config {
-  std::string path;              // Directory containing Syzygy files (.rtbw, .rtbz)
-  std::uint8_t probe_depth{1};   // Minimum search depth before probing TBs
-  std::uint8_t probe_limit{7};   // Max piece count to probe (saves time in complex positions)
-  bool use_50_move_rule{true};   // Whether DTZ respects the 50-move draw rule
+  std::string path;            // Directory containing Syzygy files (.rtbw, .rtbz)
+  std::uint8_t probe_depth{1}; // Minimum search depth before probing TBs
+  std::uint8_t probe_limit{7}; // Max piece count to probe (saves time in complex positions)
+  bool use_50_move_rule{true}; // Whether DTZ respects the 50-move draw rule
 };
 
 // Score constant for TB wins (below mate threshold, above any material)

--- a/scripts/download_syzygy.sh
+++ b/scripts/download_syzygy.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+#
+# Download Syzygy tablebase files from lichess mirror
+#
+# Usage:
+#   ./download_syzygy.sh [output_dir] [pieces]
+#
+# Examples:
+#   ./download_syzygy.sh ./syzygy 345    # Download 3-4-5 piece TBs (~1GB)
+#   ./download_syzygy.sh ./syzygy 3456   # Download 3-4-5-6 piece TBs (~155GB)
+#
+
+set -euo pipefail
+
+OUTPUT_DIR="${1:-./syzygy}"
+PIECES="${2:-345}"
+
+MIRROR="https://tablebase.lichess.ovh/tables/standard"
+
+mkdir -p "$OUTPUT_DIR"
+cd "$OUTPUT_DIR"
+
+download_file() {
+    local url="$1"
+    local file="$2"
+
+    if [[ -f "$file" ]]; then
+        echo "  [skip] $file (exists)"
+        return 0
+    fi
+
+    echo "  [download] $file"
+    if ! curl -fsSL -o "$file" "$url"; then
+        echo "  [error] Failed to download $file"
+        rm -f "$file"
+        return 1
+    fi
+    return 0
+}
+
+echo "Downloading Syzygy tablebases to: $OUTPUT_DIR"
+echo "Piece counts: $PIECES"
+echo ""
+
+# Download 3-4-5 piece tablebases
+if [[ "$PIECES" =~ [345] ]]; then
+    echo "Fetching 3-4-5 piece tablebase file list..."
+
+    # Download WDL files
+    echo "Downloading WDL files (.rtbw)..."
+    curl -fsSL "${MIRROR}/3-4-5-wdl/" | \
+        grep -oE 'K[A-Za-z]+\.rtbw' | \
+        sort -u | \
+        while read -r file; do
+            download_file "${MIRROR}/3-4-5-wdl/${file}" "$file"
+        done
+
+    # Download DTZ files
+    echo "Downloading DTZ files (.rtbz)..."
+    curl -fsSL "${MIRROR}/3-4-5-dtz/" | \
+        grep -oE 'K[A-Za-z]+\.rtbz' | \
+        sort -u | \
+        while read -r file; do
+            download_file "${MIRROR}/3-4-5-dtz/${file}" "$file"
+        done
+fi
+
+# Download 6 piece tablebases (optional, very large)
+if [[ "$PIECES" == *"6"* ]]; then
+    echo ""
+    echo "WARNING: 6-piece tablebases are ~150GB total."
+    echo "This may take several hours..."
+    echo ""
+
+    echo "Downloading 6-piece WDL files..."
+    curl -fsSL "${MIRROR}/6-wdl/" | \
+        grep -oE 'K[A-Za-z]+\.rtbw' | \
+        sort -u | \
+        while read -r file; do
+            download_file "${MIRROR}/6-wdl/${file}" "$file"
+        done
+
+    echo "Downloading 6-piece DTZ files..."
+    curl -fsSL "${MIRROR}/6-dtz/" | \
+        grep -oE 'K[A-Za-z]+\.rtbz' | \
+        sort -u | \
+        while read -r file; do
+            download_file "${MIRROR}/6-dtz/${file}" "$file"
+        done
+fi
+
+echo ""
+echo "Download complete!"
+ls -lh *.rtb* 2>/dev/null | head -20 || echo "(no files downloaded)"
+echo ""
+echo "To use with c3 engine:"
+echo "  setoption name SyzygyPath value $(pwd)"

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -27,6 +27,7 @@
 #include "c3/eval.hpp"
 #include "c3/movegen.hpp"
 #include "c3/piece.hpp"
+#include "c3/tablebase.hpp"
 
 namespace c3::search {
 namespace {
@@ -484,6 +485,29 @@ int detail::alphabeta(Position& pos, std::uint8_t depth, int alpha, int beta, Mo
     tt_move = entry->move;
   }
 
+  // SYZYGY TABLEBASE PROBE
+  // Tablebases provide perfect play for endgame positions with few pieces.
+  // Probe after TT (TT is faster) but before expensive search operations.
+  const auto tb_config = tablebase::get_config();
+  if (tablebase::is_available() && depth >= tb_config.probe_depth) {
+    const auto wdl = tablebase::probe_wdl(pos);
+    if (wdl != tablebase::WdlResult::Failed) {
+      const int tb_score = tablebase::wdl_to_score(wdl, report.ply);
+
+      if (wdl == tablebase::WdlResult::Win || wdl == tablebase::WdlResult::Loss) {
+        tt.store(pos.key, depth, eval_in(tb_score, report.ply), Bound::Exact, std::nullopt);
+        return tb_score;
+      }
+
+      if (tb_score >= beta) {
+        return beta;
+      }
+      if (tb_score <= alpha) {
+        return alpha;
+      }
+    }
+  }
+
   report.nodes += 1;
 
   const Colour colour_to_move = pos.colour_to_move;
@@ -680,6 +704,31 @@ SearchResult search(Position& pos, const Limits& limits, Reporter& reporter,
   TranspositionTable tt;
   KillerMoves killers;
   Report report;
+
+  // ROOT TABLEBASE PROBE
+  // For endgame positions where tablebases are available, we can skip
+  // the entire search and return the optimal move directly.
+  if (tablebase::is_available()) {
+    if (const auto tb_move = tablebase::probe_root_move(pos)) {
+      const auto wdl = tablebase::probe_wdl(pos);
+      const int tb_eval =
+          (wdl != tablebase::WdlResult::Failed) ? tablebase::wdl_to_score(wdl, 0) : CENTIPAWN_DRAW;
+
+      SearchResult result;
+      result.depth = 1;
+      result.eval = tb_eval;
+      result.pv = {*tb_move};
+      result.nodes = 1;
+      result.hashfull = 0;
+
+      report.depth = 1;
+      report.pv = std::make_pair(result.pv, result.eval);
+      report.tt_stats = {0, 0};
+      reporter.send(report);
+
+      return result;
+    }
+  }
 
   const std::uint8_t max_depth = limits.depth.has_value() ? *limits.depth : MAX_DEPTH;
 

--- a/src/tablebase.cpp
+++ b/src/tablebase.cpp
@@ -1,0 +1,219 @@
+#include "c3/tablebase.hpp"
+
+#include <atomic>
+#include <bit>
+#include <mutex>
+
+extern "C" {
+#include "tbprobe.h"
+}
+
+#include "c3/eval.hpp"
+
+namespace c3::tablebase {
+namespace {
+
+std::mutex g_config_mutex;
+Config g_config;
+std::atomic<bool> g_initialized{false};
+std::atomic<std::uint8_t> g_max_pieces{0};
+
+std::uint8_t count_all_pieces(const Position& pos) {
+  return static_cast<std::uint8_t>(std::popcount(pos.board.pieces_by_colour(Colour::White)) +
+                                   std::popcount(pos.board.pieces_by_colour(Colour::Black)));
+}
+
+} // namespace
+
+void set_config(const Config& config) {
+  std::lock_guard lock(g_config_mutex);
+  g_config = config;
+}
+
+Config get_config() {
+  std::lock_guard lock(g_config_mutex);
+  return g_config;
+}
+
+std::uint8_t init() {
+  const Config config = get_config();
+  if (config.path.empty()) {
+    g_initialized.store(false);
+    g_max_pieces.store(0);
+    return 0;
+  }
+
+  const bool ok = tb_init(config.path.c_str());
+  g_initialized.store(ok);
+
+  if (ok) {
+    g_max_pieces.store(static_cast<std::uint8_t>(TB_LARGEST));
+    return static_cast<std::uint8_t>(TB_LARGEST);
+  }
+
+  g_max_pieces.store(0);
+  return 0;
+}
+
+bool is_available() { return g_initialized.load() && g_max_pieces.load() > 0; }
+
+std::uint8_t max_pieces() { return g_max_pieces.load(); }
+
+void free() {
+  if (g_initialized.load()) {
+    tb_free();
+    g_initialized.store(false);
+    g_max_pieces.store(0);
+  }
+}
+
+WdlResult probe_wdl(const Position& pos) {
+  if (!is_available()) {
+    return WdlResult::Failed;
+  }
+
+  const Config config = get_config();
+  const std::uint8_t piece_count = count_all_pieces(pos);
+
+  if (piece_count > config.probe_limit || piece_count > max_pieces()) {
+    return WdlResult::Failed;
+  }
+
+  if (pos.castling_rights.value() != 0) {
+    return WdlResult::Failed;
+  }
+
+  const std::uint64_t white = pos.board.pieces_by_colour(Colour::White);
+  const std::uint64_t black = pos.board.pieces_by_colour(Colour::Black);
+  const std::uint64_t kings = pos.board.pieces(Piece::WK) | pos.board.pieces(Piece::BK);
+  const std::uint64_t queens = pos.board.pieces(Piece::WQ) | pos.board.pieces(Piece::BQ);
+  const std::uint64_t rooks = pos.board.pieces(Piece::WR) | pos.board.pieces(Piece::BR);
+  const std::uint64_t bishops = pos.board.pieces(Piece::WB) | pos.board.pieces(Piece::BB);
+  const std::uint64_t knights = pos.board.pieces(Piece::WN) | pos.board.pieces(Piece::BN);
+  const std::uint64_t pawns = pos.board.pieces(Piece::WP) | pos.board.pieces(Piece::BP);
+
+  const unsigned rule50 = config.use_50_move_rule ? pos.half_move_clock : 0;
+  const unsigned castling = 0;
+  const unsigned ep =
+      pos.en_passant_square.has_value() ? pos.en_passant_square->index() : 0;
+  const bool turn = (pos.colour_to_move == Colour::White);
+
+  const unsigned result =
+      tb_probe_wdl(white, black, kings, queens, rooks, bishops, knights, pawns, rule50, castling,
+                   ep, turn);
+
+  if (result == TB_RESULT_FAILED) {
+    return WdlResult::Failed;
+  }
+
+  return static_cast<WdlResult>(result);
+}
+
+std::optional<Move> probe_root_move(const Position& pos) {
+  if (!is_available()) {
+    return std::nullopt;
+  }
+
+  const Config config = get_config();
+  const std::uint8_t piece_count = count_all_pieces(pos);
+
+  if (piece_count > config.probe_limit || piece_count > max_pieces()) {
+    return std::nullopt;
+  }
+
+  if (pos.castling_rights.value() != 0) {
+    return std::nullopt;
+  }
+
+  const std::uint64_t white = pos.board.pieces_by_colour(Colour::White);
+  const std::uint64_t black = pos.board.pieces_by_colour(Colour::Black);
+  const std::uint64_t kings = pos.board.pieces(Piece::WK) | pos.board.pieces(Piece::BK);
+  const std::uint64_t queens = pos.board.pieces(Piece::WQ) | pos.board.pieces(Piece::BQ);
+  const std::uint64_t rooks = pos.board.pieces(Piece::WR) | pos.board.pieces(Piece::BR);
+  const std::uint64_t bishops = pos.board.pieces(Piece::WB) | pos.board.pieces(Piece::BB);
+  const std::uint64_t knights = pos.board.pieces(Piece::WN) | pos.board.pieces(Piece::BN);
+  const std::uint64_t pawns = pos.board.pieces(Piece::WP) | pos.board.pieces(Piece::BP);
+
+  const unsigned rule50 = config.use_50_move_rule ? pos.half_move_clock : 0;
+  const unsigned castling = 0;
+  const unsigned ep =
+      pos.en_passant_square.has_value() ? pos.en_passant_square->index() : 0;
+  const bool turn = (pos.colour_to_move == Colour::White);
+
+  unsigned results[TB_MAX_MOVES];
+  const unsigned result =
+      tb_probe_root(white, black, kings, queens, rooks, bishops, knights, pawns, rule50, castling,
+                    ep, turn, results);
+
+  if (result == TB_RESULT_FAILED) {
+    return std::nullopt;
+  }
+
+  const unsigned from_sq = TB_GET_FROM(result);
+  const unsigned to_sq = TB_GET_TO(result);
+  const unsigned promotes = TB_GET_PROMOTES(result);
+  const bool is_ep = TB_GET_EP(result) != 0;
+
+  const Square from = Square::from_index(static_cast<std::uint8_t>(from_sq));
+  const Square to = Square::from_index(static_cast<std::uint8_t>(to_sq));
+
+  const auto piece = pos.board.piece_at(from);
+  if (!piece.has_value()) {
+    return std::nullopt;
+  }
+
+  auto captured = pos.board.piece_at(to);
+  if (is_ep && is_pawn(*piece)) {
+    captured = pawn(!pos.colour_to_move);
+  }
+
+  std::optional<Piece> promo = std::nullopt;
+  if (promotes != TB_PROMOTES_NONE) {
+    const Colour colour = pos.colour_to_move;
+    switch (promotes) {
+    case TB_PROMOTES_QUEEN:
+      promo = queen(colour);
+      break;
+    case TB_PROMOTES_ROOK:
+      promo = rook(colour);
+      break;
+    case TB_PROMOTES_BISHOP:
+      promo = bishop(colour);
+      break;
+    case TB_PROMOTES_KNIGHT:
+      promo = knight(colour);
+      break;
+    default:
+      break;
+    }
+  }
+
+  return Move{
+      .piece = *piece,
+      .from = from,
+      .to = to,
+      .captured_piece = captured,
+      .promotion_piece = promo,
+      .is_en_passant = is_ep,
+  };
+}
+
+int wdl_to_score(WdlResult wdl, std::uint8_t ply) {
+  switch (wdl) {
+  case WdlResult::Win:
+    return CENTIPAWN_TB_WIN - static_cast<int>(ply);
+  case WdlResult::CursedWin:
+    return CENTIPAWN_DRAW + 1;
+  case WdlResult::Draw:
+    return CENTIPAWN_DRAW;
+  case WdlResult::BlessedLoss:
+    return CENTIPAWN_DRAW - 1;
+  case WdlResult::Loss:
+    return -CENTIPAWN_TB_WIN + static_cast<int>(ply);
+  case WdlResult::Failed:
+  default:
+    return 0;
+  }
+}
+
+} // namespace c3::tablebase

--- a/src/tablebase.cpp
+++ b/src/tablebase.cpp
@@ -55,9 +55,13 @@ std::uint8_t init() {
   return 0;
 }
 
-bool is_available() { return g_initialized.load() && g_max_pieces.load() > 0; }
+bool is_available() {
+  return g_initialized.load() && g_max_pieces.load() > 0;
+}
 
-std::uint8_t max_pieces() { return g_max_pieces.load(); }
+std::uint8_t max_pieces() {
+  return g_max_pieces.load();
+}
 
 void free() {
   if (g_initialized.load()) {
@@ -94,13 +98,11 @@ WdlResult probe_wdl(const Position& pos) {
 
   const unsigned rule50 = config.use_50_move_rule ? pos.half_move_clock : 0;
   const unsigned castling = 0;
-  const unsigned ep =
-      pos.en_passant_square.has_value() ? pos.en_passant_square->index() : 0;
+  const unsigned ep = pos.en_passant_square.has_value() ? pos.en_passant_square->index() : 0;
   const bool turn = (pos.colour_to_move == Colour::White);
 
-  const unsigned result =
-      tb_probe_wdl(white, black, kings, queens, rooks, bishops, knights, pawns, rule50, castling,
-                   ep, turn);
+  const unsigned result = tb_probe_wdl(white, black, kings, queens, rooks, bishops, knights, pawns,
+                                       rule50, castling, ep, turn);
 
   if (result == TB_RESULT_FAILED) {
     return WdlResult::Failed;
@@ -136,14 +138,12 @@ std::optional<Move> probe_root_move(const Position& pos) {
 
   const unsigned rule50 = config.use_50_move_rule ? pos.half_move_clock : 0;
   const unsigned castling = 0;
-  const unsigned ep =
-      pos.en_passant_square.has_value() ? pos.en_passant_square->index() : 0;
+  const unsigned ep = pos.en_passant_square.has_value() ? pos.en_passant_square->index() : 0;
   const bool turn = (pos.colour_to_move == Colour::White);
 
   unsigned results[TB_MAX_MOVES];
-  const unsigned result =
-      tb_probe_root(white, black, kings, queens, rooks, bishops, knights, pawns, rule50, castling,
-                    ep, turn, results);
+  const unsigned result = tb_probe_root(white, black, kings, queens, rooks, bishops, knights, pawns,
+                                        rule50, castling, ep, turn, results);
 
   if (result == TB_RESULT_FAILED) {
     return std::nullopt;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -23,6 +23,7 @@
 #include "c3/eval.hpp"
 #include "c3/movegen.hpp"
 #include "c3/search.hpp"
+#include "c3/tablebase.hpp"
 
 namespace c3::uci {
 
@@ -307,6 +308,9 @@ SetOptionCommand parse_setoption(
     } catch (...) {
       throw std::runtime_error("could not parse value for 'hash' option");
     }
+  } else if (name == "syzygypath" || name == "syzygyprobedepth" || name == "syzygyprobelimit" ||
+             name == "syzygy50moverule") {
+    // Syzygy options validated in handler
   } else {
     throw std::runtime_error("unknown option '" + name + "'");
   }
@@ -569,6 +573,10 @@ void run_loop_impl(std::istream& in,
                    std::to_string(search::TT_DEFAULT_SIZE_MB) + " min " +
                    std::to_string(search::TT_MIN_SIZE_MB) + " max " +
                    std::to_string(search::TT_MAX_SIZE_MB));
+        write_line("option name SyzygyPath type string default <empty>");
+        write_line("option name SyzygyProbeDepth type spin default 1 min 0 max 100");
+        write_line("option name SyzygyProbeLimit type spin default 7 min 0 max 7");
+        write_line("option name Syzygy50MoveRule type check default true");
         write_line("uciok");
         break;
 
@@ -683,6 +691,25 @@ void run_loop_impl(std::istream& in,
         }
         if (cmd.option->name == "hash") {
           engine.set_hash_size_mb(std::stoull(cmd.option->value.value()));
+        } else if (cmd.option->name == "syzygypath") {
+          auto config = tablebase::get_config();
+          config.path = cmd.option->value.value_or("");
+          tablebase::set_config(config);
+          tablebase::init();
+        } else if (cmd.option->name == "syzygyprobedepth") {
+          auto config = tablebase::get_config();
+          config.probe_depth =
+              static_cast<std::uint8_t>(std::stoi(cmd.option->value.value_or("1")));
+          tablebase::set_config(config);
+        } else if (cmd.option->name == "syzygyprobelimit") {
+          auto config = tablebase::get_config();
+          config.probe_limit =
+              static_cast<std::uint8_t>(std::stoi(cmd.option->value.value_or("7")));
+          tablebase::set_config(config);
+        } else if (cmd.option->name == "syzygy50moverule") {
+          auto config = tablebase::get_config();
+          config.use_50_move_rule = (to_lower(cmd.option->value.value_or("true")) == "true");
+          tablebase::set_config(config);
         }
         break;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(c3_tests
   rng_test.cpp
   movegen_test.cpp
   search_test.cpp
+  tablebase_test.cpp
   uci_test.cpp
   zobrist_test.cpp
 )

--- a/tests/tablebase_test.cpp
+++ b/tests/tablebase_test.cpp
@@ -1,0 +1,190 @@
+#include <gtest/gtest.h>
+
+#include "c3/eval.hpp"
+#include "c3/position.hpp"
+#include "c3/tablebase.hpp"
+
+using namespace c3;
+namespace tb = c3::tablebase;
+
+namespace {
+
+Position parse(std::string_view fen) { return Position::from_fen(fen); }
+
+} // namespace
+
+TEST(Tablebase, ConfigDefaultValues) {
+  tb::Config config = tb::get_config();
+  EXPECT_TRUE(config.path.empty());
+  EXPECT_EQ(config.probe_depth, 1);
+  EXPECT_EQ(config.probe_limit, 7);
+  EXPECT_TRUE(config.use_50_move_rule);
+}
+
+TEST(Tablebase, ConfigSetAndGet) {
+  tb::Config config;
+  config.path = "/some/path";
+  config.probe_depth = 5;
+  config.probe_limit = 6;
+  config.use_50_move_rule = false;
+
+  tb::set_config(config);
+
+  const auto retrieved = tb::get_config();
+  EXPECT_EQ(retrieved.path, "/some/path");
+  EXPECT_EQ(retrieved.probe_depth, 5);
+  EXPECT_EQ(retrieved.probe_limit, 6);
+  EXPECT_FALSE(retrieved.use_50_move_rule);
+
+  tb::set_config(tb::Config{});
+}
+
+TEST(Tablebase, NotAvailableByDefault) {
+  EXPECT_FALSE(tb::is_available());
+  EXPECT_EQ(tb::max_pieces(), 0);
+}
+
+TEST(Tablebase, ProbeFailsWhenNotAvailable) {
+  Position pos = parse("8/8/8/8/8/3k4/8/R3K3 w - - 0 1");
+  EXPECT_EQ(tb::probe_wdl(pos), tb::WdlResult::Failed);
+  EXPECT_FALSE(tb::probe_root_move(pos).has_value());
+}
+
+TEST(Tablebase, WdlToScoreWin) {
+  const int score = tb::wdl_to_score(tb::WdlResult::Win, 0);
+  EXPECT_EQ(score, tb::CENTIPAWN_TB_WIN);
+
+  const int score_ply5 = tb::wdl_to_score(tb::WdlResult::Win, 5);
+  EXPECT_EQ(score_ply5, tb::CENTIPAWN_TB_WIN - 5);
+  EXPECT_LT(score_ply5, score);
+}
+
+TEST(Tablebase, WdlToScoreLoss) {
+  const int score = tb::wdl_to_score(tb::WdlResult::Loss, 0);
+  EXPECT_EQ(score, -tb::CENTIPAWN_TB_WIN);
+
+  const int score_ply5 = tb::wdl_to_score(tb::WdlResult::Loss, 5);
+  EXPECT_EQ(score_ply5, -tb::CENTIPAWN_TB_WIN + 5);
+  EXPECT_GT(score_ply5, score);
+}
+
+TEST(Tablebase, WdlToScoreDraw) {
+  EXPECT_EQ(tb::wdl_to_score(tb::WdlResult::Draw, 0), CENTIPAWN_DRAW);
+  EXPECT_EQ(tb::wdl_to_score(tb::WdlResult::Draw, 10), CENTIPAWN_DRAW);
+}
+
+TEST(Tablebase, WdlToScoreCursedWin) {
+  const int score = tb::wdl_to_score(tb::WdlResult::CursedWin, 0);
+  EXPECT_GT(score, CENTIPAWN_DRAW);
+  EXPECT_LT(score, tb::CENTIPAWN_TB_WIN);
+}
+
+TEST(Tablebase, WdlToScoreBlessedLoss) {
+  const int score = tb::wdl_to_score(tb::WdlResult::BlessedLoss, 0);
+  EXPECT_LT(score, CENTIPAWN_DRAW);
+  EXPECT_GT(score, -tb::CENTIPAWN_TB_WIN);
+}
+
+TEST(Tablebase, ProbeRejectsCastlingRights) {
+  Position pos = parse("8/8/8/8/8/8/8/R3K2R w KQ - 0 1");
+  EXPECT_EQ(tb::probe_wdl(pos), tb::WdlResult::Failed);
+}
+
+TEST(Tablebase, ProbeRespectsProbeLimit) {
+  tb::Config config;
+  config.probe_limit = 3;
+  tb::set_config(config);
+
+  Position pos = parse("8/8/8/8/8/3k4/4P3/R3K3 w - - 0 1");
+
+  EXPECT_EQ(tb::probe_wdl(pos), tb::WdlResult::Failed);
+
+  tb::set_config(tb::Config{});
+}
+
+TEST(Tablebase, TbWinScoreBelowMate) {
+  EXPECT_LT(tb::CENTIPAWN_TB_WIN, CENTIPAWN_MATE_THRESHOLD);
+}
+
+TEST(Tablebase, TbWinScoreAboveNormalEval) {
+  EXPECT_GT(tb::CENTIPAWN_TB_WIN, 8500);
+}
+
+class TablebaseWithFiles : public ::testing::Test {
+protected:
+  void SetUp() override {
+    const std::vector<std::string> paths = {
+        "/syzygy",
+        "/opt/syzygy",
+        "./syzygy",
+        "../syzygy",
+        "../../syzygy",
+        "../../../syzygy",
+    };
+
+    for (const auto& path : paths) {
+      tb::Config config;
+      config.path = path;
+      tb::set_config(config);
+      if (tb::init() > 0) {
+        tb_available_ = true;
+        return;
+      }
+    }
+
+    tb_available_ = false;
+  }
+
+  void TearDown() override {
+    tb::free();
+    tb::set_config(tb::Config{});
+  }
+
+  bool tb_available_{false};
+};
+
+TEST_F(TablebaseWithFiles, KRvK_WhiteWins) {
+  if (!tb_available_) {
+    GTEST_SKIP() << "Syzygy tablebases not found";
+  }
+
+  Position pos = parse("8/8/8/8/8/3k4/8/R3K3 w - - 0 1");
+
+  const auto wdl = tb::probe_wdl(pos);
+  EXPECT_EQ(wdl, tb::WdlResult::Win);
+}
+
+TEST_F(TablebaseWithFiles, KRvK_BlackLoses) {
+  if (!tb_available_) {
+    GTEST_SKIP() << "Syzygy tablebases not found";
+  }
+
+  Position pos = parse("8/8/8/8/8/3k4/8/R3K3 b - - 0 1");
+
+  const auto wdl = tb::probe_wdl(pos);
+  EXPECT_EQ(wdl, tb::WdlResult::Loss);
+}
+
+TEST_F(TablebaseWithFiles, KvK_Draw) {
+  if (!tb_available_) {
+    GTEST_SKIP() << "Syzygy tablebases not found";
+  }
+
+  Position pos = parse("8/8/8/4k3/8/8/8/4K3 w - - 0 1");
+
+  const auto wdl = tb::probe_wdl(pos);
+  EXPECT_EQ(wdl, tb::WdlResult::Draw);
+}
+
+TEST_F(TablebaseWithFiles, RootProbeReturnsMove) {
+  if (!tb_available_) {
+    GTEST_SKIP() << "Syzygy tablebases not found";
+  }
+
+  Position pos = parse("8/8/8/8/8/3k4/8/R3K3 w - - 0 1");
+
+  const auto move = tb::probe_root_move(pos);
+  ASSERT_TRUE(move.has_value());
+
+  EXPECT_TRUE(move->piece == Piece::WR || move->piece == Piece::WK);
+}


### PR DESCRIPTION
## Summary

Implement Syzygy tablebase probing for perfect endgame play using the Fathom library. Adds WDL probing during search for cutoffs, root probing for optimal endgame moves, and configurable 50-move rule awareness. Includes comprehensive unit tests, download script for tablebase files, and educational documentation.

## Testing

- All 17 tablebase unit tests pass
- Existing 200 tests remain green  
- Verified no performance regression with gauntlet testing
- Successfully probes endgame positions (KRvK, KvK) with TB files

## Key Features

- UCI options: SyzygyPath, SyzygyProbeDepth, SyzygyProbeLimit, Syzygy50MoveRule
- Graceful degradation when TBs unavailable
- Download script for 3-4-5 and 6-piece tablebases
- Educational comments aligned with codebase style